### PR TITLE
Make internals visible for unit tests

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -38,3 +38,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: ComponentFactory(typeof(SumOfBestFactory))]
+[assembly: InternalsVisibleTo("LiveSplit.UnitTests")]

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -38,4 +38,3 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: ComponentFactory(typeof(SumOfBestFactory))]
-[assembly: InternalsVisibleTo("LiveSplit.UnitTests")]

--- a/TimeFormatters/RegularSumOfBestTimeFormatter.cs
+++ b/TimeFormatters/RegularSumOfBestTimeFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace LiveSplit.TimeFormatters
 {
-    class RegularSumOfBestTimeFormatter : ITimeFormatter
+    public class RegularSumOfBestTimeFormatter : ITimeFormatter
     {
         public TimeAccuracy Accuracy { get; set; }
         


### PR DESCRIPTION
Allow unit tests to be created for all TimeFormatters. See: https://github.com/LiveSplit/LiveSplit/pull/1446
